### PR TITLE
fix: Correct Firebase Admin SDK initialization

### DIFF
--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -14,7 +14,7 @@ if (!admin.apps.length) {
       credential: admin.credential.cert(serviceAccount),
     });
 } else {
-    adminApp = admin.app();
+    adminApp = admin.apps[0] as admin.app.App;
 }
 
 


### PR DESCRIPTION
The login was failing with an "Unexpected token '<'" error because the backend was crashing and returning an HTML error page instead of a JSON response.

The crash was caused by an incorrect initialization of the Firebase Admin SDK. The `adminApp` variable was not being correctly assigned when a Firebase app was already initialized. This resulted in a crash when `getAdminApp` was called.

This commit fixes the issue by correctly retrieving the existing Firebase app instance, ensuring that `adminApp` is always properly initialized.